### PR TITLE
feat: implement user progress feature

### DIFF
--- a/actions/user-progress.ts
+++ b/actions/user-progress.ts
@@ -1,0 +1,47 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
+import { auth, currentUser } from "@clerk/nextjs/server";
+
+import db from "@/db/drizzle";
+import { userProgress } from "@/db/schema";
+import { getCoursesById, getUserProgress } from "@/db/queries";
+
+export const upsertUserProgress = async (courseId: number) => {
+  const { userId } = await auth();
+  const user = await currentUser();
+
+  if (!userId || !user) throw new Error("Akses Ditolak!");
+
+  const course = await getCoursesById(courseId);
+
+  if (!course) throw new Error("Kursus tidak ditemukan!");
+
+  // if (!course.units.length || !course.units[0].lessons.length) throw new Error("Kursus masih kosong!");
+
+  const existingUserProgress = await getUserProgress();
+
+  if (existingUserProgress) {
+    await db.update(userProgress).set({
+      activeCourseId: courseId,
+      userName: user.firstName || "User",
+      userImageSrc: user.imageUrl || "/logo.png",
+    });
+
+    revalidatePath("/courses");
+    revalidatePath("/learn");
+    redirect("/learn");
+  }
+
+  await db.insert(userProgress).values({
+    userId,
+    activeCourseId: courseId,
+    userName: user.firstName || "User",
+    userImageSrc: user.imageUrl || "/logo.png",
+  });
+
+  revalidatePath("/courses");
+  revalidatePath("/learn");
+  redirect("/learn");
+};

--- a/app/(main)/courses/list.tsx
+++ b/app/(main)/courses/list.tsx
@@ -1,18 +1,37 @@
 "use client";
 
-import { courses } from "@/db/schema";
+import { toast } from "sonner";
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { courses, userProgress } from "@/db/schema";
+import { upsertUserProgress } from "@/actions/user-progress";
 
 import { Card } from "./card";
 
 type Props = {
   courses: typeof courses.$inferSelect[];
-  activeCourseId: number;
+  activeCourseId?: typeof userProgress.$inferSelect.activeCourseId;
 };
 
 export const List = ({
   courses,
   activeCourseId,
 }: Props) => {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+
+  const onClick = (id: number) => {
+    if (pending) return;
+
+    if (id === activeCourseId) return router.push("/learn");
+
+    startTransition(() => {
+      upsertUserProgress(id)
+        .catch(() => toast.error("Terjadi masalah!"));
+    });
+  };
+
   return (
     <div className="pt-7 grid grid-cols-2 lg:grid-cols-[repeat(auto-fill,minmax(210px,1fr))] gap-4">
       {courses.map((course) =>  (
@@ -21,8 +40,8 @@ export const List = ({
           id={course.id}
           title={course.title}
           imageSrc={course.imageSrc}
-          onClick={() => {}}
-          disabled={false}
+          onClick={onClick}
+          disabled={pending}
           active={course.id === activeCourseId}
         />
       ))}

--- a/app/(main)/courses/loading.tsx
+++ b/app/(main)/courses/loading.tsx
@@ -1,0 +1,11 @@
+import { Loader } from "lucide-react";
+
+const Loading = () => {
+  return (
+    <div className="w-full h-full flex items-center justify-center">
+      <Loader className="h-6 w-6 text-muted-foreground animate-spin" />
+    </div>
+  );
+};
+
+export default Loading;

--- a/app/(main)/courses/page.tsx
+++ b/app/(main)/courses/page.tsx
@@ -1,9 +1,18 @@
-import { getCourses } from "@/db/queries";
+import { getCourses, getUserProgress } from "@/db/queries";
 
 import { List } from "./list";
 
 const CoursesPage = async () => {
-  const courses = await getCourses();
+  const coursesData = getCourses();
+  const userProgressData = getUserProgress();
+
+  const [
+    courses,
+    userProgress,
+  ] = await Promise.all([
+    coursesData,
+    userProgressData,
+  ]);
 
   return (
     <div className="h-full max-w-[912px] px-3 mx-auto">
@@ -12,7 +21,7 @@ const CoursesPage = async () => {
       </h1>
       <List
         courses={courses}
-        activeCourseId={1}
+        activeCourseId={userProgress?.activeCourseId}
       />
     </div>
   );

--- a/app/(main)/learn/loading.tsx
+++ b/app/(main)/learn/loading.tsx
@@ -1,0 +1,11 @@
+import { Loader } from "lucide-react";
+
+const Loading = () => {
+  return (
+    <div className="w-full h-full flex items-center justify-center">
+      <Loader className="h-6 w-6 text-muted-foreground animate-spin" />
+    </div>
+  );
+};
+
+export default Loading;

--- a/app/(main)/learn/page.tsx
+++ b/app/(main)/learn/page.tsx
@@ -1,10 +1,23 @@
+import { redirect } from "next/navigation";
+
+import { getUserProgress } from "@/db/queries";
 import { FeedWrapper } from "@/components/feed-wrapper";
 import { UserProgress } from "@/components/user-progress";
 import { StickyWrapper } from "@/components/sticky-wrapper";
 
 import { Header } from "./header";
 
-const LearnPage = () => {
+const LearnPage = async () => {
+  const userProgressData = getUserProgress();
+
+  const [
+    userProgress,
+  ] = await Promise.all([
+    userProgressData,
+  ]);
+
+  if (!userProgress || !userProgress.activeCourse) redirect("/courses");
+
   return (
     <div className="flex flex-row-reverse gap-[48px] px-6">
       <StickyWrapper>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Nunito } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
+import { Toaster } from "@/components/ui/sonner";
 import "./globals.css";
 
 const fontNunito = Nunito({
@@ -21,6 +22,7 @@ export default function RootLayout({
     <ClerkProvider>
       <html lang="en">
         <body className={`${fontNunito.className} antialiased`}>
+          <Toaster />
           {children}
         </body>
       </html>

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/db/queries.ts
+++ b/db/queries.ts
@@ -1,9 +1,35 @@
 import { cache } from "react";
+import { eq } from "drizzle-orm";
+import { auth } from "@clerk/nextjs/server";
 
 import db from "@/db/drizzle";
+import { courses, userProgress } from "@/db/schema";
+
+export const getUserProgress = cache(async () => {
+  const { userId } = await auth();
+
+  if (!userId) return null;
+
+  const data = await db.query.userProgress.findFirst({
+    where: eq(userProgress.userId, userId),
+    with: {
+      activeCourse: true,
+    },
+  });
+
+  return data;
+});
 
 export const getCourses = cache(async () => {
   const data = await db.query.courses.findMany();
+
+  return data;
+});
+
+export const getCoursesById = cache(async (courseId: number) => {
+  const data = await db.query.courses.findFirst({
+    where: eq(courses.id, courseId),
+  });
 
   return data;
 });

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,7 +1,28 @@
-import { pgTable, serial, text } from "drizzle-orm/pg-core";
+import { relations } from "drizzle-orm";
+import { integer, pgTable, serial, text } from "drizzle-orm/pg-core";
 
 export const courses = pgTable("courses", {
   id: serial("id").primaryKey(),
   title: text("title").notNull(),
   imageSrc: text("image_src").notNull(),
 });
+
+export const coursesRelations = relations(courses, ({ many }) => ({
+  userProgress: many(userProgress),
+}));
+
+export const userProgress = pgTable("user_progress", {
+  userId: text("user_id").primaryKey(),
+  userName: text("user_name").notNull().default("User"),
+  userImageSrc: text("user_image_src").notNull().default("/logo.png"),
+  activeCourseId: integer("active_course_id").references(() => courses.id, { onDelete: "cascade" }),
+  hearts: integer("hearts").notNull().default(5),
+  points: integer("points").notNull().default(0),
+});
+
+export const userProgressRelations = relations(userProgress, ({ one }) => ({
+  activeCourse: one(courses, {
+    fields: [userProgress.activeCourseId],
+    references: [courses.id],
+  }),
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,10 @@
         "drizzle-orm": "^0.43.1",
         "lucide-react": "^0.488.0",
         "next": "15.3.0",
+        "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "sonner": "^2.0.3",
         "tailwind-merge": "^3.2.0",
         "tw-animate-css": "^1.2.5"
       },
@@ -2537,7 +2539,7 @@
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.1.tgz",
       "integrity": "sha512-ePapxDL7qrgqSF67s0h9m412d9DbXyC1n59O2st+9rjuuamWsZuD2w55rqY12CbzsZ7uVXb5Nw0gEp9Z8MMutQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2547,7 +2549,7 @@
       "version": "19.1.2",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.2.tgz",
       "integrity": "sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -6080,6 +6082,16 @@
         }
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -7071,6 +7083,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.3.tgz",
+      "integrity": "sha512-njQ4Hht92m0sMqqHVDL32V2Oun9W1+PHO9NDv9FHfJjT3JT22IG4Jpo3FPQy+mouRKCXFWO+r67v6MrHX2zeIA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "drizzle-orm": "^0.43.1",
     "lucide-react": "^0.488.0",
     "next": "15.3.0",
+    "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "sonner": "^2.0.3",
     "tailwind-merge": "^3.2.0",
     "tw-animate-css": "^1.2.5"
   },


### PR DESCRIPTION
## ✨ Ringkasan

Pull Request ini menambahkan fitur **User Progress**, yang memungkinkan pengguna untuk menyimpan dan melanjutkan progres pembelajaran mereka berdasarkan kursus yang dipilih.

## 🔧 Perubahan Utama

1. **Modifikasi `db/schema.ts`**  
   - Menambahkan tabel `user_progress` untuk menyimpan informasi progres pengguna (course aktif, hearts, points).
   - Menambahkan relasi antara `user_progress` dan `courses`.

2. **Modifikasi `db/queries.ts`**  
   - Menambahkan fungsi `getUserProgress()` untuk mendapatkan progres user dari database.

3. **Modifikasi `courses/page.tsx` dan `courses/list.tsx`**  
   - Menampilkan daftar kursus dan menandai kursus yang sedang aktif berdasarkan data `userProgress`.
   - Menambahkan logika ketika user memilih kursus baru, akan memicu proses penyimpanan progress.

4. **Modifikasi `learn/page.tsx`**  
   - Redirect ke halaman kursus jika user belum memiliki kursus aktif.
   - Menampilkan komponen `UserProgress` berdasarkan data dari database (sementara masih hardcoded untuk title, hearts, points, dll).

5. **Penambahan file `actions/user-progress.ts`**  
   - Menambahkan fungsi `upsertUserProgress` untuk menyimpan/memperbarui progres user saat memilih kursus.
   - Menggunakan `auth` dari Clerk dan `revalidatePath` dari Next.js.

6. **Penambahan file loading UI (`loading.tsx`)** untuk:
   - `app/(main)/courses/loading.tsx`
   - `app/(main)/learn/loading.tsx`

7. **Install dan integrasi `sonner` (shadcn)**  
   - Untuk feedback UI saat terjadi error ketika memilih kursus.

8. **Modifikasi `app/layout.tsx`**
   - Menambahkan `<Toaster />` untuk sonner agar muncul global toast.

## 📌 Catatan

- Untuk sementara, `UserProgress` di halaman `/learn` masih hardcoded.
- Validasi terhadap kursus yang belum memiliki unit/lesson dikomentari sementara untuk pengembangan bertahap.

---