### PR TITLE
feat: define initial database schema with relations

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,5 +1,5 @@
 import { relations } from "drizzle-orm";
-import { integer, pgTable, serial, text } from "drizzle-orm/pg-core";
+import { boolean, integer, pgEnum, pgTable, serial, text } from "drizzle-orm/pg-core";
 
 export const courses = pgTable("courses", {
   id: serial("id").primaryKey(),
@@ -9,6 +9,87 @@ export const courses = pgTable("courses", {
 
 export const coursesRelations = relations(courses, ({ many }) => ({
   userProgress: many(userProgress),
+  units: many(units),
+}));
+
+export const units = pgTable("units", {
+  id: serial("id").primaryKey(),
+  title: text("title").notNull(),
+  description: text("description").notNull(),
+  courseId: integer("course_id").references(() => courses.id, { onDelete: "cascade" }).notNull(),
+  order: integer("order").notNull(),
+});
+
+export const unitsRelations = relations(units, ({ many, one }) => ({
+  course: one(courses, {
+    fields: [units.courseId],
+    references: [courses.id],
+  }),
+  lessons: many(lessons),
+}));
+
+export const lessons = pgTable("lessons", {
+  id: serial("id").primaryKey(),
+  title: text("text").notNull(),
+  unitId: integer("unit_id").references(() => units.id, { onDelete: "cascade" }).notNull(),
+  order: integer("order").notNull(),
+});
+
+export const lessonsRelations = relations(lessons, ({ one, many }) => ({
+  unit: one(units, {
+    fields: [lessons.unitId],
+    references: [units.id],
+  }),
+  challenges: many(challenges),
+}));
+
+export const challengesEnum = pgEnum("type", ["SELECT", "ASSIST"]);
+
+export const challenges = pgTable("challenges", {
+  id: serial("id").primaryKey(),
+  lessonId: integer("lesson_id").references(() => lessons.id, { onDelete: "cascade" }).notNull(),
+  type: challengesEnum("type").notNull(),
+  question: text("question").notNull(),
+  order: integer("order").notNull(),
+});
+
+export const challengesRelations = relations(challenges, ({ one, many }) => ({
+  lesson: one(lessons, {
+    fields: [challenges.lessonId],
+    references: [lessons.id],
+  }),
+  challengeOptions: many(challengeOptions),
+  challengeProgress: many(challengeProgress),
+}));
+
+export const challengeOptions = pgTable("challenge_options", {
+  id: serial("id").primaryKey(),
+  challengeId: integer("challenge_id").references(() => challenges.id, { onDelete: "cascade" }).notNull(),
+  text: text("text").notNull(),
+  correct: boolean("correct").notNull(),
+  imageSrc: text("image_src"),
+  audioSrc: text("audio_src"),
+});
+
+export const challengeOptionsRelations = relations(challengeOptions, ({ one }) => ({
+  challenge: one(challenges, {
+    fields: [challengeOptions.challengeId],
+    references: [challenges.id],
+  }),
+}));
+
+export const challengeProgress = pgTable("challenge_progress", {
+  id: serial("id").primaryKey(),
+  userId: text("user_id").notNull(),
+  challengeId: integer("challenge").references(() => challenges.id, { onDelete: "cascade" }).notNull(),
+  completed: boolean("completed").notNull().default(false),
+});
+
+export const challengeProgressRelations = relations(challengeProgress, ({ one }) => ({
+  challenge: one(challenges, {
+    fields: [challengeProgress.challengeId],
+    references: [challenges.id],
+  }), 
 }));
 
 export const userProgress = pgTable("user_progress", {


### PR DESCRIPTION
## Pull Request Description
PR ini menambahkan skema awal database menggunakan Drizzle ORM pada branch `feature/schema`. Beberapa tabel inti yang dibuat antara lain:

- `courses`, `units`, `lessons` untuk struktur materi kursus
- `challenges`, `challenge_options`, dan `challenge_progress` untuk sistem tantangan
- `user_progress` untuk melacak progres pengguna

Relasi antar tabel juga telah ditetapkan untuk mendukung integritas data dan kemudahan dalam query. Skema ini akan menjadi dasar utama pengembangan fitur pembelajaran dan pelacakan progres ke depannya.
