### PR TITLE
Refactor Unit component to remove unused id and order props

### DIFF
--- a/app/(main)/learn/unit.tsx
+++ b/app/(main)/learn/unit.tsx
@@ -18,8 +18,8 @@ type Props = {
 };
 
 export const Unit = ({
-    id,
-    order,
+    id: _id,
+    order: _order,
     title,
     description,
     lessons,


### PR DESCRIPTION
### Ringkasan
PR ini melakukan refactor pada komponen `Unit` dengan mengganti destructuring properti `id` dan `order` menjadi `_id` dan `_order`. Tujuannya adalah untuk menghindari peringatan linter karena kedua properti tersebut belum digunakan di dalam komponen.

### Perubahan
- Aliasing properti `id` dan `order` menjadi `_id` dan `_order` di file `unit.tsx`.
- Tidak ada perubahan pada cara `Unit` dipanggil di `page.tsx`, karena `id` dan `order` masih tetap diperlukan jika nantinya digunakan.

### Catatan
Jika nanti `id` atau `order` dibutuhkan di dalam komponen `Unit`, alias `_id` dan `_order` bisa diganti kembali ke nama aslinya tanpa masalah.
